### PR TITLE
Fixed GoogleSignIn_SignOut not working correctly if sign in was never triggered before login out

### DIFF
--- a/source/GoogleSignIn_gml/extensions/GoogleSignIn/AndroidSource/Java/YYGoogleSignIn.java
+++ b/source/GoogleSignIn_gml/extensions/GoogleSignIn/AndroidSource/Java/YYGoogleSignIn.java
@@ -37,7 +37,7 @@ public class YYGoogleSignIn extends RunnerSocial
 	
 	private static final int REQ_ONE_TAP = 635;
 	
-	private SignInClient oneTapClient;
+	private SignInClient oneTapClient = null;
 	
 	public void GoogleSignIn_Show()
 	{
@@ -158,7 +158,12 @@ public class YYGoogleSignIn extends RunnerSocial
 	{
 		if (oneTapClient == null)
 		{
-			oneTapClient = Identity.getSignInClient(activity);
+			Log.d("yoyo", "GoogleSignIn_SignOut: Sign out successful.");
+			int dsMapIndex = RunnerJNILib.jCreateDsMap(null, null, null);
+			RunnerJNILib.DsMapAddString(dsMapIndex, "type", "GoogleSignIn_SignOut");
+			RunnerJNILib.DsMapAddDouble(dsMapIndex, "success", 1.0);
+			RunnerJNILib.CreateAsynEventWithDSMap(dsMapIndex, EVENT_OTHER_SOCIAL);
+			return;
 		}
 	
 		oneTapClient.signOut()
@@ -171,6 +176,8 @@ public class YYGoogleSignIn extends RunnerSocial
 					RunnerJNILib.DsMapAddString(dsMapIndex, "type", "GoogleSignIn_SignOut");
 					RunnerJNILib.DsMapAddDouble(dsMapIndex, "success", 1.0);
 					RunnerJNILib.CreateAsynEventWithDSMap(dsMapIndex, EVENT_OTHER_SOCIAL);
+					
+					oneTapClient = null;
 				}
 		})
 		.addOnFailureListener(new OnFailureListener() 

--- a/source/GoogleSignIn_gml/extensions/GoogleSignIn/AndroidSource/Java/YYGoogleSignIn.java
+++ b/source/GoogleSignIn_gml/extensions/GoogleSignIn/AndroidSource/Java/YYGoogleSignIn.java
@@ -156,6 +156,35 @@ public class YYGoogleSignIn extends RunnerSocial
 	
 	public void GoogleSignIn_SignOut()
 	{
-		oneTapClient.signOut();
+		if (oneTapClient == null)
+		{
+			oneTapClient = Identity.getSignInClient(activity);
+		}
+	
+		oneTapClient.signOut()
+		.addOnSuccessListener(new OnSuccessListener<Void>() 
+		{
+				@Override
+				public void onSuccess(Void result) {
+					Log.d("yoyo", "GoogleSignIn_SignOut: Sign out successful.");
+					int dsMapIndex = RunnerJNILib.jCreateDsMap(null, null, null);
+					RunnerJNILib.DsMapAddString(dsMapIndex, "type", "GoogleSignIn_SignOut");
+					RunnerJNILib.DsMapAddDouble(dsMapIndex, "success", 1.0);
+					RunnerJNILib.CreateAsynEventWithDSMap(dsMapIndex, EVENT_OTHER_SOCIAL);
+				}
+		})
+		.addOnFailureListener(new OnFailureListener() 
+		{
+			@Override
+			public void onFailure(@NonNull Exception e) 
+			{
+				Log.e("yoyo", "GoogleSignIn_SignOut Error: " + e.getLocalizedMessage());
+				int dsMapIndex = RunnerJNILib.jCreateDsMap(null, null, null);
+				RunnerJNILib.DsMapAddString(dsMapIndex, "type", "GoogleSignIn_SignOut");
+				RunnerJNILib.DsMapAddDouble(dsMapIndex, "success", 0.0);
+				RunnerJNILib.DsMapAddString(dsMapIndex, "error", e.getLocalizedMessage());
+				RunnerJNILib.CreateAsynEventWithDSMap(dsMapIndex, EVENT_OTHER_SOCIAL);
+			}
+		});
 	}
 }


### PR DESCRIPTION
Currently if the logout function is called when `GoogleSignIn_Show` was never called.
I added a null check as well as the missing Async Event.